### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To remove the docker instance and image you'll need to type the following at the
 ```
 podman stop ntopng
 podman rm ntopng
-podman rmi docker.io/tusc/ntopng-udm  (or "docker rmi ntopng-image" if you installed the first release)
+podman rmi docker.io/tusc/ntopng-udm  #(or "docker rmi ntopng-image" if you installed the first release)
 ```
 
 # Console Lockout


### PR DESCRIPTION
The actual smallest change ever made on github? Added a hash to the uninstall line where you have parenthesis so the copy block on github works without error when pasting into terminal

```
# podman stop ntopng
cae2433e97608461e831b815dcac877bbd776a57efd42668b46b8d86b497309a
# podman rm ntopng
cae2433e97608461e831b815dcac877bbd776a57efd42668b46b8d86b497309a
# podman rmi docker.io/tusc/ntopng-udm  (or "docker rmi ntopng-image" if you installed the first release)
-sh: syntax error: unexpected "("
```

becomes

```
# podman stop ntopng
ee056c1058234b226949687d884b2bae5a1913bd6d996330ce0cfd2fab4ddcfa
# podman rm ntopng
ee056c1058234b226949687d884b2bae5a1913bd6d996330ce0cfd2fab4ddcfa
# podman rmi docker.io/tusc/ntopng-udm  #(or "docker rmi ntopng-image" if you installed the first release)
Untagged: docker.io/tusc/ntopng-udm:latest
Deleted: da456e3aff0b2d6ba8094228dd712857d0ae0dca03b660bf87a7482d7e857906
```